### PR TITLE
修复 macos 下无法退出应用的 bug

### DIFF
--- a/main.js
+++ b/main.js
@@ -97,6 +97,10 @@ function initialize () {
       createWindow()
     }
   })
+
+  app.on('before-quit', () => {
+    forceQuit = true;
+  });
 }
 
 let tray = null

--- a/main.js
+++ b/main.js
@@ -99,8 +99,10 @@ function initialize () {
   })
 
   app.on('before-quit', () => {
-    forceQuit = true;
-  });
+    if (process.platform === 'darwin') {
+         forceQuit = true;
+    }
+ });
 }
 
 let tray = null


### PR DESCRIPTION
macos 下按 Cmd + Q 无法退出应用，只能强制杀死应用